### PR TITLE
feat!: extract UID utilities to zer-dependency submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.0.0
+
+### Major Changes
+
+- Add UID utilities as zero-dependency submodule
+
+  **BREAKING CHANGE:** UID functions are no longer exported from the main package. They are now available as a separate lightweight submodule.
+
+  ### Migration:
+
+  ```typescript
+  // Old (no longer works):
+  import { formatUid, normalizeUid } from "@tenderlift/zefix-client";
+
+  // New:
+  import { formatUid, normalizeUid } from "@tenderlift/zefix-client/uid";
+  ```
+
+  ### Features:
+  - New zero-dependency UID submodule (~1KB minified)
+  - Pure functions with TypeScript branded types for type safety
+  - Flexible input handling (CHE-123.456.789, che 123 456 789, with VAT suffixes)
+  - Functions: `normalizeUid`, `formatUid`, `isValidUidFormat`, `uidEquals`
+  - Branded type `UidCore` for normalized UIDs
+
+  This change allows users who only need UID utilities to import them without the entire ZEFIX client.
+
 ## 0.2.0
 
 ### Minor Changes
@@ -7,7 +34,6 @@
 - 88d1896: Initial release of @tenderlift/zefix-client
 
   ## Features
-
   - 🚀 **Edge-ready**: Works in Cloudflare Workers, Vercel Edge, and other edge environments
   - 🔒 **Type-safe**: Full TypeScript support with generated types from OpenAPI spec
   - 📦 **Zero runtime dependencies**: Minimal bundle size with no external dependencies
@@ -17,7 +43,6 @@
   - 🔧 **Flexible configuration**: Support for multiple authentication methods and custom settings
 
   ## API Coverage
-
   - Company search and lookup
   - Legal forms and communities data
   - SOGC publications
@@ -25,7 +50,6 @@
   - Validation utilities for UIDs and company data
 
   ## Documentation
-
   - Comprehensive examples for Node.js and Cloudflare Workers
   - Full API documentation
   - TypeScript type definitions

--- a/README.md
+++ b/README.md
@@ -141,12 +141,6 @@ export default {
 ### Utility Functions
 
 ```typescript
-// Validation utilities
-import { isValidUid, formatUid } from '@tenderlift/zefix-client';
-
-console.log(isValidUid('CHE-105.815.381')); // true
-console.log(formatUid('CHE105815381')); // 'CHE-105.815.381'
-
 // Type guards
 import { isCompany, isActiveCompany } from '@tenderlift/zefix-client';
 
@@ -154,6 +148,43 @@ if (isCompany(data) && isActiveCompany(data)) {
   console.log(`${data.name} is an active company`);
 }
 ```
+
+### UID Handling
+
+Swiss UIDs (Unternehmens-Identifikationsnummer) are unique business identifiers formatted as CHE-123.456.789. This package includes zero-dependency utilities for working with UIDs, available as a separate submodule:
+
+```typescript
+// Import as a lightweight submodule (zero dependencies, ~1KB)
+import { normalizeUid, formatUid, isValidUidFormat, uidEquals } from '@tenderlift/zefix-client/uid';
+
+// Normalize various input formats to core format (9 digits)
+normalizeUid('CHE-123.456.789')     // '123456789'
+normalizeUid('che 123 456 789')     // '123456789'
+normalizeUid('CHE-123.456.789 MWST') // '123456789'
+normalizeUid('invalid')              // undefined
+
+// Format for canonical display
+formatUid('123456789')     // 'CHE-123.456.789'
+formatUid('che123456789')  // 'CHE-123.456.789'
+
+// Validate format (structure only, no checksum)
+isValidUidFormat('CHE-123.456.789')  // true
+isValidUidFormat('che 123 456 789 TVA') // true
+isValidUidFormat('invalid')          // false
+
+// Compare UIDs ignoring formatting
+uidEquals('CHE-123.456.789', 'che 123 456 789') // true
+uidEquals('CHE-123.456.789 MWST', 'CHE123456789') // true
+```
+
+**Accepted Input Formats:**
+- Canonical: `CHE-123.456.789`
+- Various separators: `CHE 123 456 789`, `CHE.123.456.789`, `CHE123456789`
+- Case-insensitive: `che-123.456.789`
+- With VAT suffixes: `CHE-123.456.789 MWST`, `CHE-123.456.789 TVA`, `CHE-123.456.789 IVA`
+- Raw digits: `123456789`
+
+**Storage Recommendation:** Store UIDs in their normalized core format (`123456789`) for consistency and efficient database operations. Use `formatUid()` for display purposes.
 
 ### Language Support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenderlift/zefix-client",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "A zero-dependency, edge-compatible, and type-safe Zefix API client.",
   "private": false,
   "type": "module",
@@ -32,6 +32,18 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./uid": {
+      "types": "./dist/uid.d.ts",
+      "import": "./dist/uid.js",
+      "require": "./dist/uid.cjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "uid": [
+        "./dist/uid.d.ts"
+      ]
     }
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,9 @@ export {
 } from './generated/sdk.gen';
 
 // Utility exports
+export {ensureOk, ZefixError} from './utils/errors';
 export {toBase64} from './utils/node-or-worker';
 export * from './utils/type-guards';
-export {ZefixError, ensureOk} from './utils/errors';
 
 export type {Auth, ClientConfig} from './client';
 export type * from './generated/types.gen';

--- a/src/uid.ts
+++ b/src/uid.ts
@@ -1,0 +1,103 @@
+/**
+ * Swiss UID (Unternehmens-Identifikationsnummer) utilities
+ *
+ * This module provides zero-dependency utilities for working with Swiss UIDs.
+ * UIDs are the unique business identification numbers used in Switzerland,
+ * typically formatted as CHE-123.456.789.
+ *
+ * @module uid
+ */
+
+/**
+ * Branded type for normalized UID core (9 digits)
+ * This ensures type safety when working with normalized UIDs
+ */
+export type UidCore = string & {readonly __brand: 'UidCore'};
+
+/**
+ * Regular expression matching normalized UID core format (exactly 9 digits)
+ */
+const UID_CORE_RE = /^\d{9}$/;
+
+/**
+ * Regular expression matching various UID input formats
+ * Accepts: CHE-123.456.789, che 123 456 789, CHE123456789, with optional MWST/TVA/IVA suffix
+ */
+const UID_INPUT_RE = /^che[\s.-]*((?:\d[\s.]*){9})(?:\s*(?:mwst|tva|iva))?$/i;
+
+/**
+ * Normalize a UID to its core format (9 digits)
+ *
+ * @param input - The UID string to normalize
+ * @returns The normalized UID core (9 digits) or null if invalid
+ *
+ * @example
+ * normalizeUid('CHE-123.456.789') // '123456789'
+ * normalizeUid('che 123 456 789') // '123456789'
+ * normalizeUid('CHE-123.456.789 MWST') // '123456789'
+ * normalizeUid('invalid') // undefined
+ */
+export function normalizeUid(input: string): UidCore | undefined {
+	if (!input) return undefined;
+	const trimmed = input.trim();
+
+	// Try to match CHE format first
+	const match = UID_INPUT_RE.exec(trimmed);
+
+	// Extract digits either from CHE match or directly from input
+	const digits = (match ? match[1] : trimmed).replaceAll(/\D/g, '');
+
+	// Validate it's exactly 9 digits
+	return UID_CORE_RE.test(digits) ? (digits as UidCore) : undefined;
+}
+
+/**
+ * Format a UID for canonical display (CHE-123.456.789)
+ *
+ * @param input - The UID string to format
+ * @returns The formatted UID or the original input if invalid
+ *
+ * @example
+ * formatUid('123456789') // 'CHE-123.456.789'
+ * formatUid('che123456789') // 'CHE-123.456.789'
+ * formatUid('invalid') // 'invalid'
+ */
+export function formatUid(input: string): string {
+	const core = normalizeUid(input);
+	if (!core) return input;
+	return `CHE-${core.slice(0, 3)}.${core.slice(3, 6)}.${core.slice(6)}`;
+}
+
+/**
+ * Check if a string is a valid UID format (structure only, no checksum validation)
+ *
+ * @param input - The string to validate
+ * @returns True if the input is a valid UID format
+ *
+ * @example
+ * isValidUidFormat('CHE-123.456.789') // true
+ * isValidUidFormat('che 123 456 789 MWST') // true
+ * isValidUidFormat('123456789') // true
+ * isValidUidFormat('invalid') // false
+ */
+export function isValidUidFormat(input: string): boolean {
+	return normalizeUid(input) !== undefined;
+}
+
+/**
+ * Check if two UIDs are equal, ignoring formatting differences
+ *
+ * @param a - First UID to compare
+ * @param b - Second UID to compare
+ * @returns True if both UIDs represent the same entity
+ *
+ * @example
+ * uidEquals('CHE-123.456.789', 'che 123 456 789') // true
+ * uidEquals('CHE-123.456.789 MWST', 'CHE123456789') // true
+ * uidEquals('CHE-123.456.789', 'CHE-987.654.321') // false
+ */
+export function uidEquals(a: string, b: string): boolean {
+	const normalizedA = normalizeUid(a);
+	const normalizedB = normalizeUid(b);
+	return normalizedA !== undefined && normalizedA === normalizedB;
+}

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -3,11 +3,11 @@
  */
 
 import type {
-	CompanyShort,
-	CompanyFull,
-	RestApiErrorResponse,
-	LegalForm,
 	BfsCommunity,
+	CompanyFull,
+	CompanyShort,
+	LegalForm,
+	RestApiErrorResponse,
 } from '../generated/types.gen';
 
 /**
@@ -99,28 +99,6 @@ export function extractErrorMessage(error: unknown): string {
  */
 export function isActiveCompany(company: CompanyShort | CompanyFull): boolean {
 	return company.status === 'ACTIVE';
-}
-
-/**
- * Format a UID for display
- */
-export function formatUid(uid: string): string {
-	// Ensure format CHE-123.456.789
-	const cleaned = uid.replaceAll(/\D/g, '');
-	if (cleaned.length === 9) {
-		return `CHE-${cleaned.slice(0, 3)}.${cleaned.slice(3, 6)}.${cleaned.slice(6)}`;
-	}
-
-	return uid;
-}
-
-/**
- * Validate a Swiss UID format
- */
-export function isValidUid(uid: string): boolean {
-	// Match CHE-123.456.789 or CHE123456789 format
-	const pattern = /^che[-.]?(?:\d{3}\.?){2}\d{3}$/i;
-	return pattern.test(uid);
 }
 
 /**

--- a/test/uid.test.ts
+++ b/test/uid.test.ts
@@ -1,0 +1,226 @@
+import {describe, expect, it} from 'vitest';
+import {
+	formatUid,
+	isValidUidFormat,
+	normalizeUid,
+	uidEquals,
+	type UidCore,
+} from '../src/uid';
+
+describe('UID helpers', () => {
+	describe('normalizeUid', () => {
+		it('normalizes various valid input formats', () => {
+			const cases: Array<[string, string]> = [
+				['CHE-123.456.789', '123456789'],
+				['che-123.456.789', '123456789'],
+				['CHE 123 456 789', '123456789'],
+				['che 123 456 789', '123456789'],
+				['CHE123456789', '123456789'],
+				['che123456789', '123456789'],
+				['CHE-123.456.789 MWST', '123456789'],
+				['CHE-123.456.789 TVA', '123456789'],
+				['CHE-123.456.789 IVA', '123456789'],
+				['che-123.456.789 mwst', '123456789'],
+				['CHE 123.456.789 tva', '123456789'],
+				['CHE.123.456.789', '123456789'],
+				['123456789', '123456789'],
+				['  CHE-123.456.789  ', '123456789'], // With whitespace
+			];
+
+			for (const [input, expected] of cases) {
+				expect(normalizeUid(input)).toBe(expected);
+			}
+		});
+
+		it('returns undefined for invalid inputs', () => {
+			const invalidInputs = [
+				'',
+				'CHE-123.456.78', // Too short
+				'CHE-123.456.7890', // Too long
+				'CHE-ABC.DEF.GHI', // Letters instead of numbers
+				'12345678', // 8 digits
+				'1234567890', // 10 digits
+				'CHE', // No numbers
+				'invalid',
+			];
+
+			for (const input of invalidInputs) {
+				expect(normalizeUid(input)).toBeUndefined();
+			}
+
+			// Test null and undefined separately
+			expect(normalizeUid(null as any)).toBeUndefined();
+			expect(normalizeUid(undefined as any)).toBeUndefined();
+		});
+
+		it('handles edge cases with mixed separators', () => {
+			const cases: Array<[string, string | undefined]> = [
+				['CHE.123-456 789', '123456789'],
+				['CHE 123-456.789', '123456789'],
+				['che-123456789', '123456789'],
+				['CHE123.456.789', '123456789'],
+				['CHE-123-456-789', '123456789'], // Hyphens as separators
+			];
+
+			for (const [input, expected] of cases) {
+				expect(normalizeUid(input)).toBe(expected);
+			}
+		});
+	});
+
+	describe('formatUid', () => {
+		it('formats valid UIDs to canonical format', () => {
+			const cases: Array<[string, string]> = [
+				['123456789', 'CHE-123.456.789'],
+				['che123456789', 'CHE-123.456.789'],
+				['CHE 123 456 789', 'CHE-123.456.789'],
+				['CHE-123.456.789', 'CHE-123.456.789'], // Already formatted
+				['CHE-123.456.789 MWST', 'CHE-123.456.789'],
+				['che-987.654.321 tva', 'CHE-987.654.321'],
+			];
+
+			for (const [input, expected] of cases) {
+				expect(formatUid(input)).toBe(expected);
+			}
+		});
+
+		it('returns original input for invalid UIDs', () => {
+			const invalidInputs = [
+				'invalid',
+				'CHE-123.456.78',
+				'CHE-ABC.DEF.GHI',
+				'',
+				'12345678',
+			];
+
+			for (const input of invalidInputs) {
+				expect(formatUid(input)).toBe(input);
+			}
+		});
+	});
+
+	describe('isValidUidFormat', () => {
+		it('validates correct UID formats', () => {
+			const validFormats = [
+				'CHE-123.456.789',
+				'che-123.456.789',
+				'CHE 123 456 789',
+				'CHE123456789',
+				'123456789',
+				'CHE-123.456.789 MWST',
+				'che-987.654.321 tva',
+				'CHE-111.222.333 IVA',
+			];
+
+			for (const format of validFormats) {
+				expect(isValidUidFormat(format)).toBe(true);
+			}
+		});
+
+		it('rejects invalid UID formats', () => {
+			const invalidFormats = [
+				'',
+				'CHE-123.456.78',
+				'CHE-123.456.7890',
+				'CHE-ABC.DEF.GHI',
+				'12345678',
+				'1234567890',
+				'invalid',
+				'CHE',
+			];
+
+			for (const format of invalidFormats) {
+				expect(isValidUidFormat(format)).toBe(false);
+			}
+		});
+	});
+
+	describe('uidEquals', () => {
+		it('correctly compares UIDs ignoring formatting', () => {
+			const equalPairs: Array<[string, string]> = [
+				['CHE-123.456.789', 'che-123.456.789'],
+				['CHE-123.456.789', 'CHE 123 456 789'],
+				['CHE-123.456.789', 'CHE123456789'],
+				['CHE-123.456.789', '123456789'],
+				['CHE-123.456.789 MWST', 'che-123.456.789 tva'],
+				['che 123 456 789 iva', 'CHE-123.456.789'],
+			];
+
+			for (const [a, b] of equalPairs) {
+				expect(uidEquals(a, b)).toBe(true);
+				expect(uidEquals(b, a)).toBe(true); // Symmetric
+			}
+		});
+
+		it('correctly identifies non-equal UIDs', () => {
+			const nonEqualPairs: Array<[string, string]> = [
+				['CHE-123.456.789', 'CHE-987.654.321'],
+				['CHE-111.222.333', 'CHE-444.555.666'],
+				['123456789', '987654321'],
+			];
+
+			for (const [a, b] of nonEqualPairs) {
+				expect(uidEquals(a, b)).toBe(false);
+				expect(uidEquals(b, a)).toBe(false); // Symmetric
+			}
+		});
+
+		it('returns false when comparing with invalid UIDs', () => {
+			const pairs: Array<[string, string]> = [
+				['CHE-123.456.789', 'invalid'],
+				['invalid', 'CHE-123.456.789'],
+				['invalid', 'invalid'],
+				['CHE-123.456.78', 'CHE-123.456.789'],
+				['', 'CHE-123.456.789'],
+				['CHE-123.456.789', ''],
+			];
+
+			for (const [a, b] of pairs) {
+				expect(uidEquals(a, b)).toBe(false);
+			}
+		});
+	});
+
+	describe('UidCore branded type', () => {
+		it('can be used as a string', () => {
+			const uid = normalizeUid('CHE-123.456.789');
+			if (uid) {
+				// Should be usable as a string
+				expect(uid.length).toBe(9);
+				expect(uid.charAt(0)).toBe('1');
+				expect(uid.slice(0, 3)).toBe('123');
+			}
+		});
+
+		it('maintains type safety', () => {
+			const uid = normalizeUid('CHE-123.456.789');
+			if (uid) {
+				// This is a compile-time check - the type should be UidCore
+				const typedUid: UidCore = uid;
+				expect(typedUid).toBe('123456789');
+			}
+		});
+	});
+
+	describe('Real-world UID examples', () => {
+		it('handles actual Swiss company UIDs', () => {
+			// Some real (anonymized pattern) examples
+			const realUids = [
+				'CHE-105.805.461',
+				'CHE-109.537.488',
+				'CHE-114.868.376',
+				'CHE-116.281.710',
+			];
+
+			for (const uid of realUids) {
+				expect(isValidUidFormat(uid)).toBe(true);
+				expect(formatUid(uid)).toBe(uid);
+
+				// Should normalize to 9 digits
+				const normalized = normalizeUid(uid);
+				expect(normalized).not.toBeUndefined();
+				expect(normalized?.length).toBe(9);
+			}
+		});
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,22 +1,40 @@
 import {defineConfig} from 'tsup';
 
-export default defineConfig({
-	entry: ['src/index.ts'],
-	format: ['esm', 'cjs'],
-	platform: 'browser', // Critical for edge compatibility
-	target: 'es2020',
-	dts: true,
-	sourcemap: true,
-	clean: true,
-	treeshake: true,
-	minify: true,
-	splitting: false,
-	// Bundle ALL dependencies including @hey-api. This is required to keep the package
-	// zero-dependency.
-	noExternal: [
-		/@hey-api\/client-fetch/,
-		/@hey-api\/types/,
-		/^\.\/generated/, // Bundle all generated code
-	],
-	external: [], // No external runtime dependencies
-});
+export default defineConfig([
+	// Main library build
+	{
+		entry: ['src/index.ts'],
+		format: ['esm', 'cjs'],
+		platform: 'browser', // Critical for edge compatibility
+		target: 'es2020',
+		dts: true,
+		sourcemap: true,
+		clean: true,
+		treeshake: true,
+		minify: true,
+		splitting: false,
+		// Bundle ALL dependencies including @hey-api. This is required to keep the package
+		// zero-dependency.
+		noExternal: [
+			/@hey-api\/client-fetch/,
+			/@hey-api\/types/,
+			/^\.\/generated/, // Bundle all generated code
+		],
+		external: [], // No external runtime dependencies
+	},
+	// UID submodule build
+	{
+		entry: ['src/uid.ts'],
+		format: ['esm', 'cjs'],
+		platform: 'browser',
+		target: 'es2020',
+		dts: true,
+		sourcemap: true,
+		clean: false, // Don't clean, as main build already does
+		treeshake: true,
+		minify: true,
+		splitting: false,
+		outDir: 'dist',
+		external: [], // No external runtime dependencies
+	},
+]);


### PR DESCRIPTION
BREAKING CHANGE: UID functions moved to @tenderlift/zefix-client/uid submodule"