### PR TITLE
fix: pin client on globalThis to kill dual-package hazard (silent 401)

### DIFF
--- a/.changeset/shared-client-dual-package-hazard.md
+++ b/.changeset/shared-client-dual-package-hazard.md
@@ -1,0 +1,16 @@
+---
+'@tenderlift/zefix-client': patch
+---
+
+Fix dual-package hazard causing silent `401 Unauthorized`.
+
+The package ships both ESM (`dist/index.js`) and CJS (`dist/index.cjs`) builds, each
+bundling its own copy of the generated client. A process that loaded both variants —
+e.g. a CommonJS entrypoint that statically imports the client alongside an ESM
+dependency that dynamically imports it — got two independent client instances with
+separate config + interceptor chains. `configureClient()` against one was invisible to
+SDK calls resolved through the other, surfacing as `searchCompanies` returning 401 while
+`getCompanyByUid` (resolved through the configured instance) worked in the same process.
+
+The client is now pinned on `globalThis` (keyed by `Symbol.for`) so every loaded bundle
+variant shares a single config + auth interceptor chain. Public API is unchanged.

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,17 +1,17 @@
-import {client} from './generated/client.gen';
 import type {Config as GeneratedClientConfig} from './generated/client/types.gen';
-import {toBase64} from './utils/node-or-worker';
 import {
-	byBfsCommunityId as getRegistryByBfsCommunityIdSdk,
-	showChid as getCompanyByChidSdk,
-	showEhraid as getCompanyByEhraidSdk,
-	showUid as getCompanyByUidSdk,
-	list1 as getLegalFormsSdk,
-	list2 as getCommunitiesSdk,
-	byDate as getSogcByDateSdk,
-	get as getSogcPublicationsSdk,
-	search as searchCompaniesSdk,
-} from './generated/sdk.gen';
+	sharedClient as client,
+	getRegistryByBfsCommunityId as getRegistryByBfsCommunityIdSdk,
+	getCompanyByChid as getCompanyByChidSdk,
+	getCompanyByEhraid as getCompanyByEhraidSdk,
+	getCompanyByUid as getCompanyByUidSdk,
+	getLegalForms as getLegalFormsSdk,
+	getCommunities as getCommunitiesSdk,
+	getSogcByDate as getSogcByDateSdk,
+	getSogcPublications as getSogcPublicationsSdk,
+	searchCompanies as searchCompaniesSdk,
+} from './shared-client';
+import {toBase64} from './utils/node-or-worker';
 
 export type Auth = {
 	username?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,21 @@ import {ZefixApiClient, type ClientConfig} from './client';
 
 export {ZefixApiClient} from './client';
 
-// Generated client and SDK exports
-export {client} from './generated/client.gen';
+// Shared client + SDK exports. These resolve through a single globalThis-pinned
+// client so `configureClient()` applies regardless of which bundle variant
+// (ESM/CJS) the caller imported — see `shared-client.ts` for the rationale.
 export {
-	list2 as getCommunities,
-	showChid as getCompanyByChid,
-	showEhraid as getCompanyByEhraid,
-	showUid as getCompanyByUid,
-	list1 as getLegalForms,
-	byBfsCommunityId as getRegistryByBfsCommunityId,
-	byDate as getSogcByDate,
-	get as getSogcPublications,
-	search as searchCompanies,
-} from './generated/sdk.gen';
+	sharedClient as client,
+	getCommunities,
+	getCompanyByChid,
+	getCompanyByEhraid,
+	getCompanyByUid,
+	getLegalForms,
+	getRegistryByBfsCommunityId,
+	getSogcByDate,
+	getSogcPublications,
+	searchCompanies,
+} from './shared-client';
 
 // Utility exports
 export {ensureOk, ZefixError} from './utils/errors';

--- a/src/shared-client.ts
+++ b/src/shared-client.ts
@@ -1,0 +1,85 @@
+import {client as generatedClient} from './generated/client.gen';
+import {
+	byBfsCommunityId,
+	byDate,
+	get,
+	list1,
+	list2,
+	search,
+	showChid,
+	showEhraid,
+	showUid,
+} from './generated/sdk.gen';
+
+/**
+ * Dual-package-hazard guard.
+ *
+ * This package ships both an ESM build (`dist/index.js`) and a CJS build
+ * (`dist/index.cjs`), and `tsup` bundles a self-contained copy of the generated
+ * client into each. A single process can end up loading BOTH variants — e.g. a
+ * CommonJS entrypoint that statically imports us (`require` → `dist/index.cjs`)
+ * alongside an ESM dependency that `await import()`s us (`import` → `dist/index.js`).
+ *
+ * Each variant evaluates its own `createClient()` closure, with its own `_config`
+ * and its own request-interceptor chain. That means `configureClient()` called on
+ * one variant is completely invisible to SDK calls resolved through the other. In
+ * practice this surfaced as silent `401 Unauthorized` on `searchCompanies` (resolved
+ * through an unconfigured ESM instance) while `getCompanyByUid` (resolved through the
+ * configured CJS instance) kept working in the same process.
+ *
+ * The fix: pin ONE client instance on `globalThis`, keyed by a versioned
+ * `Symbol.for(...)`, so every loaded variant shares a single config + auth
+ * interceptor chain. The first variant to load wins; later variants reuse it.
+ */
+const SHARED_CLIENT_KEY = Symbol.for(
+	'@tenderlift/zefix-client/shared-client@1',
+);
+
+type GlobalWithSharedClient = typeof globalThis & {
+	[SHARED_CLIENT_KEY]?: typeof generatedClient;
+};
+
+const globalScope = globalThis as GlobalWithSharedClient;
+
+/**
+ * The process-wide ZEFIX client. All public SDK functions and `ZefixApiClient`
+ * resolve their config + auth through this single instance regardless of which
+ * bundle variant (ESM/CJS) the caller imported.
+ */
+const resolvedClient = globalScope[SHARED_CLIENT_KEY] ?? generatedClient;
+globalScope[SHARED_CLIENT_KEY] = resolvedClient;
+export const sharedClient = resolvedClient;
+
+// Public SDK functions bound to the shared client. Defaulting `client` to
+// `sharedClient` (rather than the variant-local generated client the raw SDK
+// captures) is what makes `configureClient()` apply across bundle variants. An
+// explicit `options.client` still wins because it is spread last.
+export const searchCompanies = ((options) =>
+	search({client: sharedClient, ...options})) as typeof search;
+
+export const getCompanyByUid = ((options) =>
+	showUid({client: sharedClient, ...options})) as typeof showUid;
+
+export const getCompanyByChid = ((options) =>
+	showChid({client: sharedClient, ...options})) as typeof showChid;
+
+export const getCompanyByEhraid = ((options) =>
+	showEhraid({client: sharedClient, ...options})) as typeof showEhraid;
+
+export const getLegalForms = ((options) =>
+	list1({client: sharedClient, ...options})) as typeof list1;
+
+export const getCommunities = ((options) =>
+	list2({client: sharedClient, ...options})) as typeof list2;
+
+export const getRegistryByBfsCommunityId = ((options) =>
+	byBfsCommunityId({
+		client: sharedClient,
+		...options,
+	})) as typeof byBfsCommunityId;
+
+export const getSogcByDate = ((options) =>
+	byDate({client: sharedClient, ...options})) as typeof byDate;
+
+export const getSogcPublications = ((options) =>
+	get({client: sharedClient, ...options})) as typeof get;

--- a/test/dual-package-hazard.test.ts
+++ b/test/dual-package-hazard.test.ts
@@ -1,0 +1,89 @@
+import {execSync} from 'node:child_process';
+import {existsSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import {dirname, join} from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import {beforeAll, describe, expect, it} from 'vitest';
+
+/**
+ * Regression test for the dual-package hazard that produced silent
+ * `401 Unauthorized` on `searchCompanies` in a mixed CJS/ESM process (see
+ * `src/shared-client.ts`). The hazard only manifests when BOTH built bundles are
+ * loaded in one process, so this test loads `dist/index.js` (ESM) and
+ * `dist/index.cjs` (CJS) side by side and asserts they share one client + one auth
+ * state. Requires a build; CI runs `pnpm build` before tests, and we build on the
+ * fly if `dist/` is missing for standalone `vitest` runs.
+ */
+
+// Minimal surface of the built module, kept local so this runtime test does not
+// depend on the source's generated response types.
+type ZefixApi = {
+	client: unknown;
+	configureClient: (config: {
+		auth: {username: string; password: string};
+		customFetch: typeof fetch;
+	}) => unknown;
+	searchCompanies: (options: {
+		body: {name: string; canton: string; activeOnly: boolean};
+	}) => Promise<unknown>;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distDir = join(here, '..', 'dist');
+const esmPath = join(distDir, 'index.js');
+const cjsPath = join(distDir, 'index.cjs');
+
+const requireCjs = createRequire(import.meta.url);
+
+const loadEsm = async (): Promise<ZefixApi> =>
+	(await import(pathToFileURL(esmPath).href)) as ZefixApi;
+const loadCjs = (): ZefixApi => requireCjs(cjsPath) as ZefixApi;
+
+beforeAll(() => {
+	if (!existsSync(esmPath) || !existsSync(cjsPath)) {
+		execSync('pnpm build', {cwd: join(here, '..'), stdio: 'inherit'});
+	}
+});
+
+describe('dual-package hazard', () => {
+	it('exports the same client instance from the ESM and CJS builds', async () => {
+		const esm = await loadEsm();
+		const cjs = loadCjs();
+
+		expect(esm.client).toBe(cjs.client);
+	});
+
+	it('configureClient on one build authorizes SDK calls resolved through the other', async () => {
+		const esm = await loadEsm();
+		const cjs = loadCjs();
+
+		const seenAuthHeaders: Array<string | undefined> = [];
+		const fakeFetch: typeof fetch = async (input) => {
+			const request = input as Request;
+			seenAuthHeaders.push(request.headers.get('Authorization') ?? undefined);
+			return new Response(
+				JSON.stringify([{uid: 'CHE-123.456.789', name: 'Acme AG'}]),
+				{
+					status: 200,
+					headers: {'Content-Type': 'application/json'},
+				},
+			);
+		};
+
+		// Configure auth + transport through the CJS build...
+		cjs.configureClient({
+			auth: {username: 'zefix-user', password: 'zefix-pass'},
+			customFetch: fakeFetch,
+		});
+
+		// ...then call the SDK function exported by the ESM build. Pre-fix this
+		// resolved an unconfigured ESM-local client (no fakeFetch, no auth) so the
+		// fake transport was never reached.
+		await esm.searchCompanies({
+			body: {name: 'Acme', canton: 'ZH', activeOnly: true},
+		});
+
+		expect(seenAuthHeaders).toHaveLength(1);
+		expect(seenAuthHeaders[0]).toMatch(/^Basic /);
+	});
+});


### PR DESCRIPTION
## Problem

`@tenderlift/zefix-client` ships both an ESM build (`dist/index.js`) and a CJS build (`dist/index.cjs`), and `tsup` bundles a self-contained copy of the generated client into each. When a single process loads **both** variants — e.g. a CommonJS entrypoint that statically imports the client (`require` → `.cjs`) alongside an ESM dependency that dynamically imports it (`await import()` → `.js`) — each variant evaluates its own `createClient()` closure with its own `_config` and its own request-interceptor chain.

`configureClient()` mutates exactly one of those instances. SDK calls resolved through the **other** instance never see the auth interceptor, so they fire unauthenticated. In production this surfaced as `searchCompanies` returning **`401 Unauthorized`** while `getCompanyByUid` — resolved through the configured instance — succeeded in the *same process, same `configureClient()` call*.

This is the classic Node.js dual-package hazard.

## Fix

Pin a single client on `globalThis`, keyed by a versioned `Symbol.for(...)`, in a new `src/shared-client.ts`. Every loaded bundle variant now resolves the same client → one config + one auth interceptor chain. The first variant to load wins; later variants reuse it.

- `ZefixApiClient` (`src/client.ts`) registers its auth/throttle interceptor on the shared client.
- All public SDK exports (`searchCompanies`, `getCompanyByUid`, …) default `options.client` to the shared client (an explicit `options.client` still wins).
- **Public API unchanged.** Single-runtime consumers behave exactly as before; only the cross-variant case is fixed.

## Test

`test/dual-package-hazard.test.ts` loads both built bundles in one process and asserts they (a) export the same `client` instance and (b) that `configureClient()` on the CJS build authorizes an SDK call resolved through the ESM build. Verified this test **fails on the pre-fix build with the exact production symptom** (`401 Unauthorized`) and passes after the fix.

```
Test Files  4 passed | 1 skipped (5)
     Tests  19 passed | 15 skipped
```

typecheck ✓ · xo lint ✓ · build ✓ (ESM+CJS) · node + workers tests ✓

## Release

Changeset included (`patch` → 1.0.3). Downstream (TenderLift monorepo) will bump to 1.0.3 to cure the same hazard for the M2 award-contractor matcher's ZEFIX P5 pass and every other `configureClient`-based consumer (API, ingestor, scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)